### PR TITLE
Fix: remove ensure_login from user signup and login

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,9 +99,13 @@ GEM
     method_source (1.0.0)
     mimemagic (0.3.5)
     mini_mime (1.0.2)
+    mini_portile2 (2.5.0)
     minitest (5.14.4)
     msgpack (1.4.2)
     nio4r (2.5.7)
+    nokogiri (1.11.1)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
     nokogiri (1.11.1-x86_64-linux)
       racc (~> 1.4)
     public_suffix (4.0.6)
@@ -199,6 +203,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
+  ruby
   x86_64-linux
 
 DEPENDENCIES

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,29 +1,29 @@
 class ApplicationController < ActionController::Base
-    protect_from_forgery with: :exception 
+  protect_from_forgery with: :exception
 
-    helper_method :current_user, :logged_in?
+  helper_method :current_user, :logged_in?
 
-    def ensure_login
-      redirect_to new_session_path unless current_user
-    end
+  def ensure_login
+    redirect_to new_session_path unless logged_in?
+  end
 
-    def current_user
-      @current_user ||= User.find(session[:user_id]) if session[:user_id]
-    end
+  def current_user
+    @current_user ||= User.find(session[:user_id]) if session[:user_id]
+  end
 
-    def logged_in?
-      current_user
-    end
+  def logged_in?
+    current_user
+  end
 
-    def event_params 
-      params.require(:event).permit(:date, :details)
-    end
+  def event_params
+    params.require(:event).permit(:date, :details)
+  end
 
-    def user_params
-      params.require(:user).permit(:name)
-    end
+  def user_params
+    params.require(:user).permit(:name)
+  end
 
-    def attendance_params
-      params.require(:attendance).permit(:attended_events_id)
-    end
+  def attendance_params
+    params.require(:attendance).permit(:attended_events_id)
+  end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,10 +1,10 @@
 class EventsController < ApplicationController
   before_action :ensure_login, only: %i[create show]
+
   def index
     @event = Event.all
     @past_events = Event.past
     @upcoming_events = Event.upcoming_event
-
   end
 
   def new
@@ -18,25 +18,22 @@ class EventsController < ApplicationController
       redirect_to events_path
     else
       render :new
-
     end
   end
 
-  def show 
+  def show
     @event = find(params[:id])
     @created_events = current_user.created_events
   end
 
-  def show 
-    @attendance = current_user.attendances.find_or_initialize_by(attendance_params)
+  # A conflict? You have two show actions
+  #def show
+    #@attendance = current_user.attendances.find_or_initialize_by(attendance_params)
 
-    if @attendance.save
-      redirect_to root_path
-
-    else
-      render :new
-    end
-  end
-
-
+    #if @attendance.save
+      #redirect_to root_path
+    #else
+      #render :new
+    #end
+  #end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,13 +1,13 @@
 class SessionsController < ApplicationController
-  before_action :ensure_login, only: %i[new create destroy]
+  before_action :ensure_login, only: %i[destroy]
 
   def new
     @user = User.new
   end
 
-  def create 
+  def create
     @user = User.find_by(name: params[:name])
-    if @user 
+    if @user
       session[:user_id] = @user.id
       redirect_to events_path, notice: "Welcome #{@user.id}!"
     else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,4 @@
 class UsersController < ApplicationController
-  before_action :ensure_login, only: %i[new create]
-
   def new
     @user = User.new
   end
@@ -10,7 +8,6 @@ class UsersController < ApplicationController
 
     if @user.save
       redirect_to root_path
-
     else
       render :new
     end
@@ -18,12 +15,12 @@ class UsersController < ApplicationController
 
   def show
     @user = find_by(params[:name])
-
   end
 
   def destroy
     session.delete(:current_user)
     flash[:notice] = 'You have successfully logged out.'
+
     redirect_to root_url
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,6 +18,6 @@
 
       <%= yield %>
     </div>
-    
+
   </body>
 </html>


### PR DESCRIPTION
- The first problem was your app required users to be logged in when they wanted to log in and the second one was your app required users to be logged in for signing up. Fixed that.
- Also please look at the `events_controller`, you have two `show` actions, I'll comment out one of the `show` actions and make a PR. 